### PR TITLE
ch-allergyintolerance package name adjusted

### DIFF
--- a/input/fsh/SD_according_to_IPS.fsh
+++ b/input/fsh/SD_according_to_IPS.fsh
@@ -16,8 +16,8 @@ Description: "Definition for the MedicationStatement resource in the context of 
 * category from ChRadOrderVSExample (required)
 
 Profile: ChEtocAllergyIntolerance
-//Parent: ChAllergyIntolerance
-Parent: AllergyIntolerance // Workaround
+Parent: ChAllergyIntolerance
+// Parent: AllergyIntolerance // Workaround
 Id: ch-etoc-allergyintolerance
 Title: "CH eTOC AllergyIntolerance"
 Description: "Definition for the AllergyIntolerance resource in the context of electronic transition of care."

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -29,7 +29,7 @@ dependencies:
   ch.fhir.ig.ch-orf: current
   ch.fhir.ig.ch-core: 2.0.0
 
-  ch-allergyintolerance: current
+  ch.fhir.ig.ch-allergyintolerance: current
   ch.fhir.ig.ch-emed: 0.2.0
   ch.fhir.ig.ch-vacd: 0.1.0
 

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -12,7 +12,7 @@ status: draft
 license: CC-BY-SA-4.0
 copyright: CC-BY-SA-4.0
 jurisdiction: urn:iso:std:iso:3166#CH
-date: 2021-01-14
+date: 2021-06-03
 version: 0.1.0
 fhirVersion: 4.0.1
 copyrightYear: 2021+

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -24,9 +24,11 @@ contact:
   telecom:
     system: url
     value: https://www.hl7.ch
+
 dependencies:
   ch.fhir.ig.ch-orf: current
   ch.fhir.ig.ch-core: 2.0.0
+  ch.fhir.ig.ch-allergyintolerance: current
 
 pages:
   index.html:

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -28,7 +28,7 @@ contact:
 dependencies:
   ch.fhir.ig.ch-orf: current
   ch.fhir.ig.ch-core: 2.0.0
-  ch.fhir.ig.ch-allergyintolerance: current
+  ch-allergyintolerance: current
 
 pages:
   index.html:


### PR DESCRIPTION
ch-allergyintolerance uses a different convention then the other swiss ig's, see:

https://github.com/hl7ch/ch-allergyintolerance/issues/2